### PR TITLE
Relative paths

### DIFF
--- a/Packages/ChessX.pkgproj
+++ b/Packages/ChessX.pkgproj
@@ -625,7 +625,7 @@
 						<key>BACKGROUND_PATH</key>
 						<dict>
 							<key>PATH</key>
-							<string>/Users/ni/Documents/Projects/chessx/data/images/icons-128/chessx.png</string>
+							<string>data/images/icons-128/chessx.png</string>
 							<key>PATH_TYPE</key>
 							<integer>0</integer>
 						</dict>
@@ -643,7 +643,7 @@
 						<key>BACKGROUND_PATH</key>
 						<dict>
 							<key>PATH</key>
-							<string>/Users/jens/Documents/Programmieren/Projects/chessx/data/images/icons-64/chessx.png</string>
+							<string>data/images/icons-64/chessx.png</string>
 							<key>PATH_TYPE</key>
 							<integer>0</integer>
 						</dict>
@@ -658,7 +658,7 @@
 				<key>BACKGROUND_PATH</key>
 				<dict>
 					<key>PATH</key>
-					<string>/Users/jens/Documents/Programmieren/Projects/chessx/data/images/icons-64/chessx.png</string>
+					<string>data/images/icons-64/chessx.png</string>
 					<key>PATH_TYPE</key>
 					<integer>0</integer>
 				</dict>


### PR DESCRIPTION
In the pkgProj file there are some absolute paths that does not exist in
most systems, and thus **I believe** they could be referenced as
relative paths